### PR TITLE
Pd external: use pd_error() instead of error()

### DIFF
--- a/pure-data/asdf~.c
+++ b/pure-data/asdf~.c
@@ -36,7 +36,7 @@ void *asdf_tilde_new(t_floatarg f)
   float arg = f;
   x->signal_outlets = f;
   if (arg < 0.0 || arg != x->signal_outlets) {
-    error("asdf~: argument has to be a non-negative integer");
+    pd_error(NULL, "asdf~: argument has to be a non-negative integer");
     return NULL;
   }
   x->x_canvas = canvas_getcurrent();


### PR DESCRIPTION
The `error()` function has been removed, see https://github.com/pure-data/externals-howto#error.